### PR TITLE
Require OMERO 5.3 for compatibility with IDR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN yum -y install tkinter
 
 RUN useradd -m features
 ARG OMEGO_OPTS
-RUN /opt/omero/omego/bin/omego download py --sym OMERO.py $OMEGO_OPTS
+RUN /opt/omero/omego/bin/omego download py --release 5.3 --sym OMERO.py $OMEGO_OPTS
 
 RUN printf 'PATH=$PATH:/build/OMERO.py/bin\n' > /etc/profile.d/omero.sh && \
     printf '/build/OMERO.py/lib/python\n' > /usr/lib/python2.7/site-packages/omero.pth

--- a/scripts/omero/map_series.py
+++ b/scripts/omero/map_series.py
@@ -31,6 +31,7 @@ import getpass
 from string import uppercase as LETTERS
 from operator import itemgetter
 
+import omero
 from omero.gateway import BlitzGateway
 
 DEFAULT_USER = getpass.getuser()
@@ -53,10 +54,11 @@ def main(argv):
     if not args.out_file:
         args.out_file = "map_screen_%d.tsv" % args.screen_id
     passwd = getpass.getpass()
-    conn = BlitzGateway(
-        args.user, passwd, host=args.host, port=args.port, group=args.group
-    )
-    conn.connect()
+    client = omero.client(host=args.host, port=args.port)
+    client.createSession(args.user, passwd)
+    conn = BlitzGateway(client_obj=client)
+    conn.SERVICE_OPTS.setOmeroGroup('-1')
+    conn.setSecure(True)
     screen = conn.getObject("Screen", args.screen_id)
     print "writing to %s" % args.out_file
     print "SCREEN: %s" % screen.name


### PR DESCRIPTION
Require OMERO 5.3 for compatibility with IDR

Commit 7fa4a0879bcf63b148e53cdaf2e1bd8d0401a648 fixes  scripts/omero/map_series.py to work with OMERO.py 5.3. It looks like something was broken: https://trello.com/c/zebaFaV2/315-blitzgatewayuser-password-hosthost-doesnt-work

This was discovered whilst trying to repeat https://github.com/IDR/idr-metadata/blob/0.4.4/scripts/celery/README.md#convert-avro-features-to-hdf5